### PR TITLE
Fix typo in game choices for Rock Paper Scissor

### DIFF
--- a/PYTHON/Rock Paper Scissor/rock_paper_scissor.py
+++ b/PYTHON/Rock Paper Scissor/rock_paper_scissor.py
@@ -37,7 +37,7 @@ def play():
                 c_score+=1
                 print("\nComputer wins!!!")
         else:
-            print("\nPlease enter choice between['rock','paper','season']")
+            print("\nPlease enter choice between['rock','paper','scissor']")
             print("\nNeed to restart program again....")
             exit()
         print(f"\nplayer score:{p_score} || computer score:{c_score}")


### PR DESCRIPTION
Fixed a typo in the Rock–Paper–Scissors game by correcting "season" to "scissor" in the user input prompt and error message. This change improves clarity and ensures the instructions accurately reflect the valid choices. No other changes were made.